### PR TITLE
letzte issues beenden

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,4 @@ $RECYCLE.BIN/
 */config/config.php
 */config/database.php
 /phpmyadmin/*
+/uploads/*

--- a/application/controllers/insert.php
+++ b/application/controllers/insert.php
@@ -79,8 +79,9 @@ class Insert extends CI_Controller {
 	// insert file helper
 	function insert_file_helper() {
 		$this->load->model ( 'document_model' );
-		if ($documents = $this->document_model->get_all_Document ()) {
-			$data ['all_d'] = $documents;
+		//einfach alle Documents rausholen
+		if ($documents = $this->document_model->get_Documents (FALSE, FALSE, TRUE)) {
+			$data ['documents'] = $documents;
 		}
 		return $data;
 	}
@@ -88,15 +89,15 @@ class Insert extends CI_Controller {
 	// validierung des geinserteten authors
 	function validate_i_author() {
 		// Author muss name und email haben, alle felder pflicht
-		$this->form_validation->set_rules ( 'i_author_name', 'Author name', 'trim|required|' );
-		$this->form_validation->set_rules ( 'i_author_mail', 'Email', 'trim|required' );
+		$this->form_validation->set_rules ( 'input_author_name', 'Author name', 'trim|required|' );
+		$this->form_validation->set_rules ( 'input_author_mail', 'Email', 'trim|required' );
 		// wenn nicht dann noch mal eingeben
 		if ($this->form_validation->run () == FALSE) {
 			$this->insert_author ();
 		} else {
 			// input abgreifen
-			$name = $this->input->post ( 'i_author_name' );
-			$email = $this->input->post ( 'i_author_mail' );
+			$name = $this->input->post ( 'input_author_name' );
+			$email = $this->input->post ( 'input_author_mail' );
 			
 			// author_model laden
 			$this->load->model ( 'author_model' );
@@ -119,12 +120,12 @@ class Insert extends CI_Controller {
 	// validierung der geinserteten classification
 	function validate_i_class() {
 		// es muss doch einen name dafür geben
-		$this->form_validation->set_rules ( 'i_class_name', 'Classification name', 'trim|required|' );
+		$this->form_validation->set_rules ( 'input_class_name', 'Classification name', 'trim|required|' );
 		if ($this->form_validation->run () == FALSE) {
 			$this->insert_class ();
 		} else {
 			
-			$name = $this->input->post ( 'i_class_name' );
+			$name = $this->input->post ( 'input_class_name' );
 			$this->load->model ( 'classification_model' );
 			$query = $this->classification_model->create_Classification ( $name );
 			
@@ -142,15 +143,15 @@ class Insert extends CI_Controller {
 	//
 	function validate_i_project() {
 		// project nr muss ausserdem numerisch sein
-		$this->form_validation->set_rules ( 'i_project_name', 'Project Name', 'trim|required|' );
-		$this->form_validation->set_rules ( 'i_project_number', 'Project Number', 'trim|required|numeric' );
+		$this->form_validation->set_rules ( 'input_project_name', 'Project Name', 'trim|required|' );
+		$this->form_validation->set_rules ( 'input_project_number', 'Project Number', 'trim|required|numeric' );
 		
 		if ($this->form_validation->run () == FALSE) {
 			$this->insert_project ();
 		} else {
 			
-			$name = $this->input->post ( 'i_project_name' );
-			$number = $this->input->post ( 'i_project_number' );
+			$name = $this->input->post ( 'input_project_name' );
+			$number = $this->input->post ( 'input_project_number' );
 			$this->load->model ( 'project_model' );
 			$query = $this->project_model->create_Project ( $name, $number );
 			
@@ -166,7 +167,7 @@ class Insert extends CI_Controller {
 		}
 	}
 	function validate_i_document() {
-		$this->form_validation->set_rules ( 'i_document_title', 'Title', 'trim|required|' );
+		$this->form_validation->set_rules ( 'input_document_title', 'Title', 'trim|required|' );
 		$this->form_validation->set_rules ( 'projects', 'Project', 'trim|greater_than[0]|' );
 		$this->form_validation->set_rules ( 'classification', 'Classification', 'trim|greater_than[0]|' );
 		// ausgewälte id muss größer als 1 sein, damit ist gesichert dass diese felder belegt ist
@@ -177,11 +178,11 @@ class Insert extends CI_Controller {
 			$this->insert_document ();
 		} else {
 			
-			$title = $this->input->post ( 'i_document_title' );
-			$abstract = $this->input->post ( 'i_document_abstract' );
+			$title = $this->input->post ( 'input_document_title' );
+			$abstract = $this->input->post ( 'input_document_abstract' );
 			$class = $this->input->post ( 'classifications' );
 			$project = $this->input->post ( 'projects' );
-			$keyword = $this->input->post ( 'i_document_keywords' );
+			$keyword = $this->input->post ( 'input_document_keywords' );
 			//authors greifen wir aus der tabelle, genauer gesagt aus der hiddenbereich, weil es multichoice auf sich hat
 			$array_authors = $this->input->post ( 'hiddenid' );
 			
@@ -240,7 +241,7 @@ class Insert extends CI_Controller {
       //entsprechenden model laden
       $this->load->model($model);
       
-      // alle möglichen einträge nach dem model laden die mit dem übergebenen buchstaben beginnen
+      // alle moeglichen eintraege nach dem model laden die mit dem uebergebenen buchstaben beginnen
       switch ($model) {
       	case "project_model": 
       		$hints = $this->project_model->getHints($entered);
@@ -248,9 +249,10 @@ class Insert extends CI_Controller {
       	case "author_model":
       		$hints = $this->author_model->getHints($entered);
       		break;
-      	case "classification_model":
+      		//class wird aus dem grund der einfachheit nicht diese funktion zugeteilt
+      	/* case "classification_model":
       		$hints = $this->classification_model->getHints($entered);
-      		break;
+      		break; */
       	case "document_model":
       		$hints = $this->document_model->getHints($entered);
       		break;

--- a/application/controllers/search.php
+++ b/application/controllers/search.php
@@ -128,9 +128,6 @@ class Search extends CI_Controller {
       	case "author_model":
       		$hints = $this->author_model->getHints($entered);
       		break;
-      	case "classification_model":
-      		$hints = $this->classification_model->getHints($entered);
-      		break;
       }
       
 
@@ -154,7 +151,16 @@ class Search extends CI_Controller {
       $doc_id = $this->input->get('doc_id');
 
       $data['document'] = $this->document_model->get_Document($doc_id);
-
+      
+      //da die informationen aus kreuztabellen auch hergeholt werden muessen, loadet man hier die models
+      $this->load->model('author_model');
+      $this->load->model('keyword_model');
+      $this->load->model('file_model');
+      //und queryergebnis in $data einholen
+	  $data['authors'] = $this->author_model->get_Author_by_DocumentID($doc_id);
+	  $data['keywords'] = $this->keyword_model->get_Keyword_By_DocumentID($doc_id);
+	  $data['files'] = $this->file_model->get_File_By_DocumentID($doc_id);
+	  
       $this->load->view('search/popup_view', $data);
    }
 }

--- a/application/models/author_model.php
+++ b/application/models/author_model.php
@@ -111,6 +111,21 @@ class Author_model extends CI_Model {
    function delete_Author() {
       return FALSE;
    }
+   
+   /**
+    * @param document_id 
+    * @return bool
+    */
+   function get_Author_by_DocumentID($document_id) {
+   	$this->db->select('storage_author.name as autor_name');
+   	$this->db->join('storage_document_has_author', 'storage_document_has_author.author_id = storage_author.id');
+   	$this->db->where('storage_document_has_author.document_id', $document_id);
+   	$authors = $this->db->get('storage_author');
+   	if ($authors->num_rows () > 0) {
+   		return $authors;
+   	}
+   	return false;
+   }
 }
 
 /* End of file author_model.php */

--- a/application/models/document_model.php
+++ b/application/models/document_model.php
@@ -182,7 +182,7 @@ class Document_model extends CI_Model {
     * @return bool
     */
    function getHints($entered) {
-      //here muss alias gestellt werden, denn showHint() in insert.php hat $hint->name fest geschrieben, aber hier heisst es aber title
+      //here muss alias gestellt werden, denn showHint() in insert.php hat $hint->name fest geschrieben, aber hier heisst es title
       $this->db->select('id, title as name');
       $this->db->like('title', $entered, 'after');
       $result = $this->db->get('storage_document');

--- a/application/models/file_model.php
+++ b/application/models/file_model.php
@@ -42,6 +42,22 @@ class File_model extends CI_Model {
    function delete_File() {
 
    }
+   
+   /**
+    * 
+    * @param document_id $document_id
+    * @return bool
+    */
+   function get_File_By_DocumentID($document_id) {
+   	$this->db->select('storage_file.id as f_id, storage_file.file as f_file, storage_file.md5 as f_md5, storage_file.name as f_name');
+   	$this->db->join('storage_document_has_file', 'storage_document_has_file.file_id = storage_file.id');
+   	$this->db->where('storage_document_has_file.document_id', $id);
+   	$files = $this->db->get('storage_file');
+   	if($files->num_rows()>0) {
+   		return $files;
+   	}
+   	return false;
+   }
 
 }
 /* End of file file_model.php */

--- a/application/models/keyword_model.php
+++ b/application/models/keyword_model.php
@@ -42,6 +42,22 @@ class Keyword_model extends CI_Model {
    function delete_Keyword() {
 
    }
+   
+   /**
+    * 
+    * @param document_id $id
+    * @return bool
+    */
+   function get_Keyword_by_DocumentID($document_id) {
+   	$this->db->select('storage_keyword.name as keyword_name');
+   	$this->db->join('storage_document_has_keyword', 'storage_document_has_keyword.keyword_id = storage_keyword.id');
+   	$this->db->where('storage_document_has_keyword.document_id', $document_id);
+   	$keywords = $this->db->get('storage_keyword');
+   	if($keywords->num_rows()>0) {
+   		return $keywords;
+   	}
+   	return false;
+   }
 
 
 }

--- a/application/views/insert/insert_author_view.php
+++ b/application/views/insert/insert_author_view.php
@@ -6,19 +6,21 @@
 
    <p>
       <?php
-     		$this->table->add_row(form_label ( 'Name: ', 'i_author_name' ), form_input ( array (
+     		echo form_label ( 'Name: ', 'input_author_name' );
+     		echo form_input ( array (
 					'id' => 'i_author_name',
 					'name' => 'i_author_name',
 					'placeholder' => 'New Author' 
-			) ));
+			) );
      		
-     		$this->table->add_row(form_label ( 'Email: ', 'i_author_mail'),form_input( array (
+     		echo br(1);
+     		
+     		echo form_label ( 'Email: ', 'input_author_mail');
+     		echo form_input( array (
 					'id' => 'i_author_mail',
 					'name' => 'i_author_mail',
 					'placeholder' => 'Emailadress'			
-			)));
-     		
-     		echo $this->table->generate();
+			));
 			?>
    </p>
    

--- a/application/views/insert/insert_class_view.php
+++ b/application/views/insert/insert_class_view.php
@@ -6,13 +6,12 @@
 
    <p>
       <?php
-      		$this->table->add_row(form_label ( 'Name: ', 'i_class_name' ), form_input ( array (
+      		echo form_label ( 'Name: ', 'input_class_name' );
+      		echo form_input ( array (
 					'id' => 'i_class_name',
 					'name' => 'i_class_name',
 					'placeholder' => 'New Classification' 
-			) ));
-      		
-      		echo $this->table->generate();
+			) );
 			?>
    </p>
    

--- a/application/views/insert/insert_document_view.php
+++ b/application/views/insert/insert_document_view.php
@@ -7,12 +7,12 @@
       <?php 
       		//title eingabefeld
       		echo form_label('Title: ', 'title');
-      		echo form_input(array('id' => 'title', 'name' => 'i_document_title', 'placeholder' => 'Title', 'autofocus' => 'autofocus'));
+      		echo form_input(array('id' => 'title', 'name' => 'input_document_title', 'placeholder' => 'Title', 'autofocus' => 'autofocus'));
 			echo br(1);
 			
       		//projekt eingabefeld
       		echo form_label('Project: ', 'project');
-      		echo form_input(array('name' => 'i_document_projects', 'id' => 'project', 'onkeyup' => 'javascript:showHint(this)'));
+      		echo form_input(array('name' => 'input_document_projects', 'id' => 'project', 'onkeyup' => 'javascript:showHint(this)'));
       		echo br(1);
 
             // projekt dropdown
@@ -29,7 +29,7 @@
       		
       		//author eingabefeld
       		echo form_label('Author: ', 'author');
-      		echo form_input(array('name' => 'i_document_authors', 'id' => 'author', 'onkeyup' => 'javascript:showHint(this)'));
+      		echo form_input(array('name' => 'input_document_authors', 'id' => 'author', 'onkeyup' => 'javascript:showHint(this)'));
       		echo br(1);
 
             // author dropdown
@@ -44,13 +44,13 @@
       		//keyword eingabefeld
       		echo form_label('Keyword: ', 'keyword');
       		echo br(1);
-      		echo form_textarea(array('id' => 'i_document_keywords', 'name' => 'i_document_keywords', 'placeholder' => 'delimited by comma'));
+      		echo form_textarea(array('id' => 'input_document_keywords', 'name' => 'input_document_keywords', 'placeholder' => 'delimited by comma'));
       		echo br(1);
       		
       		//abstract eingabefeld
       		echo form_label('Abstract: ', 'abstract');
       		echo br(1);
-      		echo form_textarea(array('id' => 'i_document_abstract', 'name' => 'i_document_abstract', 'placeholder' => 'Please type your abstract text here'));
+      		echo form_textarea(array('id' => 'input_document_abstract', 'name' => 'input_document_abstract', 'placeholder' => 'Please type your abstract text here'));
       		echo br(1);
       		
       		echo form_submit('add_doc', 'Add Document'); 

--- a/application/views/insert/insert_project_view.php
+++ b/application/views/insert/insert_project_view.php
@@ -6,17 +6,21 @@
 
    <p>
       <?php
-      		$this->table->add_row(form_label ( 'Project Name: ', 'i_project_name' ), form_input ( array (
+      		echo form_label ( 'Project Name: ', 'i_project_name' );
+      		echo form_input ( array (
 					'id' => 'i_project_name',
 					'name' => 'i_project_name',
 					'placeholder' => 'Project Name' 
-			) ));
-			$this->table->add_row(form_label ( 'Project Number: ', 'i_project_number'), form_input( array (
+			) );
+      		
+      		echo br(1);
+      		
+			echo form_label ( 'Project Number: ', 'i_project_number');
+			echo form_input( array (
 					'id' => 'i_project_number',
 					'name' => 'i_project_number',
 					'placeholder' => 'Project Number'			
-			)));
-			echo $this->table->generate();
+			));
 			?>
    </p>
    

--- a/application/views/mainDirectory_view.php
+++ b/application/views/mainDirectory_view.php
@@ -13,8 +13,15 @@
          'screeny'    => '500'
       );
 
-      foreach ($documents->result() as $row) {
-         $this->table->add_row(anchor_popup('search/popup?doc_id=' . $row->id, '<strong>' . $row->title . '</strong>', $atts), $row->classification, $row->project);
+      //sess abfragen zur bestimmung ob popupfenster aufrufbar sein soll
+      if ($this->session->userdata('is_logged_in')) {
+	      foreach ($documents->result() as $row) {
+	         $this->table->add_row(anchor_popup('search/popup?doc_id=' . $row->id, '<strong>' . $row->title . '</strong>', $atts), $row->classification, $row->project);
+	      }
+      } else {
+      	foreach ($documents->result() as $row) {
+      		$this->table->add_row('<strong>' . $row->title . '</strong>', $row->classification, $row->project);
+      	}
       }
 
       echo $this->table->generate();

--- a/application/views/search/search_advanced_view.php
+++ b/application/views/search/search_advanced_view.php
@@ -36,7 +36,7 @@
    <p>
       <?php
       echo form_label('Projektauswahl', 'projects');
-      //das gleiche wie oben, das element wird ��bergeben
+      //das gleiche wie oben, das element wird uebergeben
       $attributes = 'id="projects" size="1" onclick="javascript:putSelected(this)"';
       echo form_dropdown('projects', $projects, array(), $attributes);
       ?>

--- a/js/ajax.js
+++ b/js/ajax.js
@@ -14,7 +14,7 @@
 function showHint(element) {
   //die entsprechende dropdown id basteln. bsp: project -> #projects
   var element_id = "#" + element.id + "s";
-  //das zusammenhängende model basteln
+  //das zusammenhaengende model basteln
   var model = element.id + "_model";
 
   $.ajax({
@@ -34,10 +34,12 @@ function showHint(element) {
  * @param output_element
  *
  */
-function putSelected (input_element, output_element) {
-  var input_element_id = input_element.id
+function putSelected (input_element) {
+  var input_element_id = input_element.id;
+  //es scheint dieser haessliche ausdruck doch unentbeherlich zu sein :)
+  var output_element_id = input_element_id.substr(0, input_element_id.length-1); 
   var selected = document.getElementById(input_element_id).selectedOptions;
-  document.getElementById(output_element).value = selected[0].text;
+  document.getElementById(output_element_id).value = selected[0].text;
 
 }
 
@@ -106,8 +108,8 @@ function validateSignUp() {
  *
  */
 //warum hier findet ajax kein einsatz: weil die zwischengespeicherte auswahl sowieso jederzeit nach dem einfuegen von
-//anderem benutzer geloescht werden, ajax schafft nicht das mitzubekommen weil ajax letztlich durch instant-action
-//aktiviert ist wie onclick oder so. ein loeschvorgang von anderem user zaehlt offenbar nicht dazu
+//anderem benutzer geloescht werden koennen, ajax schafft nicht das mitzubekommen weil ajax letztlich durch action
+//von dem selben user aktiviert ist wie onclick oder so. ein loeschvorgang von anderem user zaehlt offenbar nicht dazu
 function showRow(obj) {
   if (obj.value != 0) {
     //isChoosed helperfunktion, verhindert mehrfachauswahl von einem eintrag
@@ -121,7 +123,7 @@ function showRow(obj) {
       var nameCell = row.insertCell(row.cells.length);
       var buttonCell = row.insertCell(row.cells.length);
       var hiddenCell = row.insertCell(row.cells.length);
-      // Inhalten einfügen, einmal id und einmal name
+      // Inhalten einfuegen, einmal id und einmal name
       idCell.innerHTML = obj.value;
       nameCell.innerHTML = obj.options[obj.selectedIndex].text;
       //loeschbutton


### PR DESCRIPTION
1. alle insert views tabelfrei
2. gitignore ein eintrag mehr: uploads folder
3. umläute teilweise umgeschrieben
4. ein paar variablename, ein paar die in queries sind und ein paar aus
   htmlattribute und und und, sind sprechend umgeschrieben
5. get_Autor($document_id) und die anderen zwei ähnliche methoden, die
   ausgehend von einer document_id die informationen aus kreuztabelle
   fetchen, sind von nun an nicht mehr in document_model aufbewahrt,
   sondern in jeweiligen models und umbenannt auf
   get_Autor_by_DocumentID($document_id)
6. putSelected() in ajax hat die stringmanipulation wieder aufgenommen
7. mainDirectory bietet jetzt keinen links mehr zu der detalierten
   ansicht von den documents ohne die anmeldung
